### PR TITLE
Duration and SelfDuration

### DIFF
--- a/Profiler/06_built-in-measure-script-demo.ps1
+++ b/Profiler/06_built-in-measure-script-demo.ps1
@@ -51,7 +51,7 @@ $trace = $(foreach ($t in $traceCore) {
     $e.EndOffset = $t.Extent.EndOffset
     $r.Extent = $e
     $r.StartTime = $t.StartTime
-    $r.Duration = $t.Duration
+    $r.SelfDuration = $t.SelfDuration
     $r.Index = $index
 
     $r
@@ -72,18 +72,18 @@ Write-Host -ForegroundColor Blue "Get-Profile is done."
 
 # but how do we know what is slow? Well it's simple: 
 $profiles.Top10 |
-    Format-Table -Property Percent, HitCount, Duration, Average, Name, Line, Text
+    Format-Table -Property Percent, HitCount, SelfDuration, Average, Name, Line, Text
 # exit
 break 
 
 
 $profiles.Files | Select-Object -Property Path
 # hello.ps1
-$profiles.Files[2].Profile | Format-Table -Property Line, Duration, HitCount, Text
+$profiles.Files[2].Profile | Format-Table -Property Line, SelfDuration, HitCount, Text
 
 
 break 
 
 # but how do we know what is slow? Well it's simple: 
 $profiles.Top10 |
-    Format-Table -Property Percent, HitCount, Duration, Average, Line, Text, CommandHits
+    Format-Table -Property Percent, HitCount, SelfDuration, Average, Line, Text, CommandHits

--- a/Profiler/Invoke-Script.ps1
+++ b/Profiler/Invoke-Script.ps1
@@ -176,7 +176,7 @@ function Invoke-Script {
                 Write-Host "Run $i$(if (1 -lt $sides.Count) { " - $side" }) failed after $($sw.Elapsed) with $_."
             }
 
-            $null = $run.Add(@{ Error = $err; Duration = $sw.Elapsed; Side = $side })
+            $null = $run.Add(@{ Error = $err; SelfDuration = $sw.Elapsed; Side = $side })
         }
     }
 
@@ -187,7 +187,7 @@ function Invoke-Script {
             $b = $run[$r]
             $a = $run[$r + 1]
 
-            $diff = [int]($a.Duration.TotalMilliseconds - $b.Duration.TotalMilliseconds)
+            $diff = [int]($a.SelfDuration.TotalMilliseconds - $b.SelfDuration.TotalMilliseconds)
             if ($diff -eq 0) { 
                 $beforeColor = $afterColor = "Yellow"
             }
@@ -201,9 +201,9 @@ function Invoke-Script {
             }
 
             Write-Host -NoNewline "Run $(${r}/2): "
-            Write-Host -ForegroundColor $beforeColor $b.Duration -NoNewline 
+            Write-Host -ForegroundColor $beforeColor $b.SelfDuration -NoNewline 
             Write-Host -NoNewline " -> "
-            Write-Host -ForegroundColor $afterColor $a.Duration -NoNewline 
+            Write-Host -ForegroundColor $afterColor $a.SelfDuration -NoNewline 
             Write-Host " ($($diff) ms)"
         }
     }

--- a/Profiler/Profiler.psd1
+++ b/Profiler/Profiler.psd1
@@ -69,6 +69,7 @@ FunctionsToExport = @(
     'Invoke-Script', 
     'Trace-Script', 
     'Get-LatestTrace'
+    'Show-ScriptExecution'
 )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/Profiler/Profiler.psm1
+++ b/Profiler/Profiler.psm1
@@ -1,5 +1,5 @@
 # for BP to attach
-Import-Module "$PSScriptRoot/bin/net452/Profiler.dll"
+Import-Module "$PSScriptRoot/bin/net452/Profiler.dll" -ErrorAction Stop
 
 # last 10 runs, show times to see how it went
 
@@ -9,4 +9,4 @@ Import-Module "$PSScriptRoot/bin/net452/Profiler.dll"
 . "$PSScriptRoot/Trace-Script.ps1"
 
 
-Export-ModuleMember -Function 'Invoke-Script', 'Trace-Script', 'Get-LatestTrace'
+Export-ModuleMember -Function 'Invoke-Script', 'Trace-Script', 'Get-LatestTrace', 'Show-ScriptExecution'

--- a/Profiler/Trace-ScriptInternal.ps1
+++ b/Profiler/Trace-ScriptInternal.ps1
@@ -115,7 +115,7 @@ function Trace-ScriptInternal {
             $e.EndOffset = $t.Extent.EndOffset
             $r.Extent = $e
             $r.StartTime = $t.StartTime
-            $r.Duration = $t.Duration
+            $r.SelfDuration = $t.SelfDuration
             $r.Index = $index
 
             $index++

--- a/Profiler/Trace-ScriptInternal.ps1
+++ b/Profiler/Trace-ScriptInternal.ps1
@@ -99,7 +99,7 @@ function Trace-ScriptInternal {
     }
 
     $trace = $result.Trace
-    $normalizedTrace = [Collections.Generic.List[object]]::new()
+    $normalizedTrace = [Collections.Generic.List[Profiler.ProfileEventRecord]]::new($trace.Count)
     Write-Host -Foreground Magenta "Tracing done. Got $($trace.Count) trace events."
     if ($UseNativePowerShell7Profiler) {
         Write-Host "Used native tracer from PowerShell 7. Normalizing trace."

--- a/Profiler/Trace-ScriptInternal.ps1
+++ b/Profiler/Trace-ScriptInternal.ps1
@@ -38,39 +38,39 @@ function Trace-ScriptInternal {
         foreach ($i in 1..$Preheat) {
             Write-Host -Foreground Magenta  "Warm up $i"
 
-            try {
-                if ($UseNativePowerShell7Profiler) {
-                    $null = Measure-Script $ScriptBlock
-                }
-                else {
-                    $isPS7 = 7 -eq $PSVersionTable.PSVersion.Major
-                    if (1 -eq $i -and $isPS7) {
-                        Write-Host -ForegroundColor Magenta "In PowerShell 7 all output is disabled for the first warmup. Just wait..."
-                        $externalUiField = $host.UI.GetType().GetField("_externalUI", [System.Reflection.BindingFlags]"Instance, NonPublic")
-                        $externalUi = $externalUiField.GetValue($host.UI)
-                    }
-                    try {
-                        # remove the UI to prevent all the debug output to be dumped on the screen
-                        # when we are not able to replace tha calls to TraceLine in pwsh7 with harmony
-                        # because it is noisy and really slow
-                        # might replace with a delegating wrapper to only ignore debug messages later
-                        if (1 -eq $i -and $isPS7) {
-                            $externalUiField.SetValue($host.UI, $null)
-                        }
 
-                        $null = Measure-ScriptHarmony $ScriptBlock
-                    } 
-                    finally { 
-                        if (1 -eq $i -and $isPS7) {
-                            # revert
-                            $externalUiField.SetValue($host.UI, $externalUi)
-                        }
+            if ($UseNativePowerShell7Profiler) {
+                $null = Measure-Script $ScriptBlock
+            }
+            else {
+                $isPS7 = 7 -eq $PSVersionTable.PSVersion.Major
+                if (1 -eq $i -and $isPS7) {
+                    Write-Host -ForegroundColor Magenta "In PowerShell 7 all output is disabled for the first warmup. Just wait..."
+                    $externalUiField = $host.UI.GetType().GetField("_externalUI", [System.Reflection.BindingFlags]"Instance, NonPublic")
+                    $externalUi = $externalUiField.GetValue($host.UI)
+                }
+                try {
+                    # remove the UI to prevent all the debug output to be dumped on the screen
+                    # when we are not able to replace tha calls to TraceLine in pwsh7 with harmony
+                    # because it is noisy and really slow
+                    # might replace with a delegating wrapper to only ignore debug messages later
+                    if (1 -eq $i -and $isPS7) {
+                        $externalUiField.SetValue($host.UI, $null)
+                    }
+
+                    $result = Measure-ScriptHarmony $ScriptBlock
+                    if ($null -ne $result.Error) { 
+                        Write-Host -ForegroundColor Red "Warm up failed with $($result.Error)."
+                    }
+                } 
+                finally { 
+                    if (1 -eq $i -and $isPS7) {
+                        # revert
+                        $externalUiField.SetValue($host.UI, $externalUi)
                     }
                 }
             }
-            catch {
-                Write-Host "Warm up failed with $_."
-            }
+            
         }
     }
 
@@ -83,22 +83,22 @@ function Trace-ScriptInternal {
 
     Write-Host -Foreground Magenta  "Tracing..."
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
-    try {
-        if ($UseNativePowerShell7Profiler) {
-            $trace = Measure-Script $ScriptBlock
-        }
-        else {
-            $trace = Measure-ScriptHarmony $ScriptBlock
-        }
-        $sw.Stop()
+
+    if ($UseNativePowerShell7Profiler) {
+        $result = Measure-Script $ScriptBlock
+    }
+    else {
+        $result = Measure-ScriptHarmony $ScriptBlock
+    }
+    $sw.Stop()
+    if ($null -eq $result.Error) {
         Write-Host -Foreground Magenta  "Run $i$(if (1 -lt $sides.Count) { " - $side" }) finished after $($sw.Elapsed)"
     }
-    catch { 
-        $sw.Stop()
-        Write-Host "Run $i$(if (1 -lt $sides.Count) { " - $side" }) failed after $($sw.Elapsed) with $_."
+    else {
+        Write-Host -ForegroundColor Red "Run $i$(if (1 -lt $sides.Count) { " - $side" }) failed after $($sw.Elapsed) with $($result.Error)."
     }
 
-
+    $trace = $result.Trace
     $normalizedTrace = [Collections.Generic.List[object]]::new()
     Write-Host -Foreground Magenta "Tracing done. Got $($trace.Count) trace events."
     if ($UseNativePowerShell7Profiler) {
@@ -132,18 +132,26 @@ function Trace-ScriptInternal {
 }
 
 function Measure-ScriptHarmony ($ScriptBlock) {
-    # ensure all output to pipeline is dumped
-    $null = & {
-        try {
-            [Profiler.Tracer]::PatchOrUnpatch($ExecutionContext, $true, $false)
-            Set-PSDebug -Trace 1
-            & $ScriptBlock
-        } 
-        finally {
-            Set-PSDebug -Trace 0
-            [Profiler.Tracer]::PatchOrUnpatch($ExecutionContext, $false, $false)
+    try {
+        # ensure all output to pipeline is dumped
+        $null = & {
+            try {
+                [Profiler.Tracer]::PatchOrUnpatch($ExecutionContext, $true, $false)
+                Set-PSDebug -Trace 1
+                & $ScriptBlock
+            } 
+            finally {
+                Set-PSDebug -Trace 0
+                [Profiler.Tracer]::PatchOrUnpatch($ExecutionContext, $false, $false)
+            }
         }
     }
+    catch {
+        $err = $_
+    }
 
-    [Profiler.Tracer]::Hits
+    @{
+        Trace = [Profiler.Tracer]::Hits
+        Error = $err
+    }
 }

--- a/csharp/Profiler/ProfileEventRecord.cs
+++ b/csharp/Profiler/ProfileEventRecord.cs
@@ -14,10 +14,10 @@ namespace Profiler
         public TimeSpan StartTime;
 
         /// <summary>
-        /// Duration of event.
+        /// SelfDuration of event.
         /// </summary>
+        public TimeSpan SelfDuration;
         public TimeSpan Duration;
-        public TimeSpan CallDuration;
 
         /// <summary>
         /// Script text.
@@ -64,8 +64,8 @@ namespace Profiler
 
     public enum CallReturnProcess
     {
-        Process = 0,
-        Call,
+        Call = 0,
         Return,
+        Process
     }
 }

--- a/csharp/Profiler/ProfileEventRecord.cs
+++ b/csharp/Profiler/ProfileEventRecord.cs
@@ -17,6 +17,7 @@ namespace Profiler
         /// Duration of event.
         /// </summary>
         public TimeSpan Duration;
+        public TimeSpan CallDuration;
 
         /// <summary>
         /// Script text.
@@ -54,5 +55,17 @@ namespace Profiler
         public string Text => Extent.Text;
         public long Timestamp => StartTime.Ticks;
 
+        public int Level;
+
+        public CallReturnProcess Flow;
+
+        public int ReturnIndex;
+    }
+
+    public enum CallReturnProcess
+    {
+        Process = 0,
+        Call,
+        Return,
     }
 }

--- a/csharp/Profiler/ProfileEventRecord.cs
+++ b/csharp/Profiler/ProfileEventRecord.cs
@@ -59,7 +59,10 @@ namespace Profiler
 
         public CallReturnProcess Flow;
 
+        // where we returned if we are a call, otherwise our own index
         public int ReturnIndex;
+        // who called us
+        public int CallerIndex;
     }
 
     public enum CallReturnProcess

--- a/csharp/Profiler/Tracer.cs
+++ b/csharp/Profiler/Tracer.cs
@@ -34,7 +34,7 @@ namespace Profiler
 
             if (!patch)
             {
-                SetDurationAndAddToHits(ref _previousHit, Stopwatch.GetTimestamp());
+                SetSelfDurationAndAddToHits(ref _previousHit, Stopwatch.GetTimestamp());
             }
 
             Harmony harmony = new Harmony("fix.debugger");
@@ -116,12 +116,12 @@ namespace Profiler
             // we are using structs so we need to insert the final struct to the 
             // list instead of inserting it to the list, and keeping reference to modify it later
             // so when we are on second event (index 1) we modify the first (index 0) with the correct
-            // duration (start of index 0 until start of index 1 = duration of index 0) and then add it to 
+            // SelfDuration (start of index 0 until start of index 1 = SelfDuration of index 0) and then add it to 
             // the final list
             // We need to do the same when unpatching to get the last event
             if (_index > 0)
             {
-                SetDurationAndAddToHits(ref _previousHit, timestamp);
+                SetSelfDurationAndAddToHits(ref _previousHit, timestamp);
             }
 
 
@@ -145,9 +145,9 @@ namespace Profiler
             _index++;
         }
 
-        private static void SetDurationAndAddToHits(ref ProfileEventRecord eventRecord, long timestamp)
+        private static void SetSelfDurationAndAddToHits(ref ProfileEventRecord eventRecord, long timestamp)
         {
-            eventRecord.Duration = TimeSpan.FromTicks(timestamp - eventRecord.Timestamp);
+            eventRecord.SelfDuration = TimeSpan.FromTicks(timestamp - eventRecord.Timestamp);
             Tracer.Hits.Add(eventRecord);
         }
     }

--- a/demo-scripts/MyScript.ps1
+++ b/demo-scripts/MyScript.ps1
@@ -17,4 +17,6 @@ else {
     $Values | foreach {
         $newValues += $_ + 10
     }
+    
+    Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10; Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10;Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10; Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10; Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10; Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10;Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10; Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10;
 }

--- a/demo-scripts/MyScript.ps1
+++ b/demo-scripts/MyScript.ps1
@@ -17,6 +17,4 @@ else {
     $Values | foreach {
         $newValues += $_ + 10
     }
-    
-    Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10; Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10;Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10; Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10; Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10; Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10;Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10; Start-Sleep -Milliseconds 10;  Start-Sleep -Milliseconds 10;
 }

--- a/demo-scripts/SleepyScript.ps1
+++ b/demo-scripts/SleepyScript.ps1
@@ -1,0 +1,14 @@
+function a () { 
+   Start-Sleep -Milliseconds 100
+}
+
+function b () { 
+    a
+}
+
+function c () {
+    a
+    b
+}
+
+c

--- a/demo.ps1
+++ b/demo.ps1
@@ -10,4 +10,3 @@ $trace.Top50 | Format-Table
 
 # Try it for yourself by running the commands from this demo, or by invoking this file as
 # . ./demo.ps1
-

--- a/demo3.ps1
+++ b/demo3.ps1
@@ -1,0 +1,38 @@
+### SleepyScript.ps1
+function a () { 
+    Start-Sleep -Milliseconds 100
+ }
+ 
+ function b () { 
+     a
+ }
+ 
+ function c () {
+     a
+     b
+ }
+ 
+c
+
+## Duration per-line and per itself, and finding what was slow
+Import-Module $PSScriptRoot/Profiler/Profiler.psm1 -Force
+
+# Runs the script 1 time, with 1 warm up run (this is needed in PowerShell 7)
+$trace = Trace-Script { & "demo-scripts/SleepyScript.ps1" } -Preheat 1
+
+$trace.Top50 | Format-Table
+
+# oooh call to function 'c' is slow
+$slowLine = $trace.Top50 | Where-Object text -eq 'c'
+$slowLine | Format-Table
+
+# it was called just once (hit), and by itself (Duration) takes < 1ms, but the code it calls 
+# takes over 200 ms (CallDuration), let's see what happens in the meantime
+$hit = $slowLine.Hits[0]
+$trace.Events[$hit.Index..$hit.ReturnIndex] | Format-Table
+
+# and if that is too many calls, let's see the top 50 from that that themselves take the most
+$trace.Events[$hit.Index..$hit.ReturnIndex] | 
+    Sort-Object -Descending Duration | 
+    Select-Object -First 50 | 
+    Format-Table

--- a/demo3.ps1
+++ b/demo3.ps1
@@ -26,13 +26,13 @@ $trace.Top50 | Format-Table
 $slowLine = $trace.Top50 | Where-Object text -eq 'c'
 $slowLine | Format-Table
 
-# it was called just once (hit), and by itself (Duration) takes < 1ms, but the code it calls 
-# takes over 200 ms (CallDuration), let's see what happens in the meantime
+# it was called just once (hit), and by itself (SelfDuration) takes < 1ms, but the code it calls 
+# takes over 200 ms (Duration), let's see what happens in the meantime
 $hit = $slowLine.Hits[0]
 $trace.Events[$hit.Index..$hit.ReturnIndex] | Format-Table
 
 # and if that is too many calls, let's see the top 50 from that that themselves take the most
 $trace.Events[$hit.Index..$hit.ReturnIndex] | 
-    Sort-Object -Descending Duration | 
+    Sort-Object -Descending SelfDuration | 
     Select-Object -First 50 | 
     Format-Table


### PR DESCRIPTION
Do a big rename.

`CallDuration` becomes just `Duration`, and `Duration` becomes `SelfDuration`. 

The output now looks more familiar, showing items ordered by duration. For quick overview of what takes the most time, with the possibility to break it down multiple ways.