### PR TITLE
Fix extra output from internals on start

### DIFF
--- a/csharp/Profiler/Tracer.cs
+++ b/csharp/Profiler/Tracer.cs
@@ -76,8 +76,9 @@ namespace Profiler
                 var extent = (IScriptExtent)currentPositionProperty.GetValue(functionContext);
                 
                 Trace(extent, scriptBlock, level);
+                // Set-PSDebug -Trace 1 is no longer automatically logged for some reason,
+                // but we get the & $ScriptBlock like our first event
             };
-            TraceLine();
         }
 
         public static void Unpatch ()

--- a/demo-scripts/ThrowingScript.ps1
+++ b/demo-scripts/ThrowingScript.ps1
@@ -1,0 +1,19 @@
+
+function a () {
+    throw "aaa"
+}
+
+function b () {
+    a
+}
+
+function c () { 
+    b
+}
+
+try { 
+    c
+}
+catch {
+    "failed"
+}


### PR DESCRIPTION
Start is automatically logged but end is not, removing the extra tracing on start.