### PR TITLE
Add classes for output types

### DIFF
--- a/Profiler/Trace-Script.ps1
+++ b/Profiler/Trace-Script.ps1
@@ -210,21 +210,21 @@ function Trace-Script {
 
         $lineNumber = $hit.Line
         if (-not $file.Lines.ContainsKey($lineNumber)) {
-            $lineProfile = [PSCustomObject] @{
-                Percent      = 0
-                HitCount     = 0 
-                Duration     = [TimeSpan]::Zero
-                Average      = [TimeSpan]::Zero
-                SelfDuration = [TimeSpan]::Zero
-                SelfAverage  = [TimeSpan]::Zero
+            $lineProfile = [Profiler.LineProfile] @{
+                # Percent      = 0
+                # HitCount     = 0 
+                # Duration     = [TimeSpan]::Zero
+                # Average      = [TimeSpan]::Zero
+                # SelfDuration = [TimeSpan]::Zero
+                # SelfAverage  = [TimeSpan]::Zero
     
                 Name         = $file.Name
                 Line         = $lineNumber
                 Text         = $hit.Text
                 Path         = $key
-                IsInFile     = $false
-                Hits         = [Collections.Generic.List[object]]::new()
-                CommandHits  = @{}
+                # IsInFile     = $false # Not available in class
+                # Hits         = [System.Collections.Generic.List[Profiler.ProfileEventRecord]]::new()
+                # CommandHits  = New-Object 'System.Collections.Generic.Dictionary[Uint,Profiler.CommandHit]'
             }
             $file.Lines.Add($lineNumber, $lineProfile)
         }
@@ -254,12 +254,12 @@ function Trace-Script {
             $commandHit.HitCount++
         }
         else { 
-            $commandHit = [PSCustomObject] @{
+            $commandHit = [Profiler.CommandHit] @{
                 Line         = $hit.Line # start from 1 as in file
                 Column       = $hit.Column
                 SelfDuration = $hit.SelfDuration
-                # Duration     = 0
-                HitCount     = 1
+                # Duration     = 0 # Not available in class
+                # HitCount     = 1
                 Text         = $hit.Text
             }
             $lineProfile.CommandHits.Add($hit.Column, $commandHit)
@@ -345,15 +345,15 @@ function Trace-Script {
     Select-Object -First 50
 
     $script:processedTrace = [PSCustomObject] @{ 
-        Top50Duration     = $top50Duration
-        Top50Average      = $top50Average
-        Top50HitCount     = $top50HitCount
-        Top50SelfDuration = $top50SelfDuration
-        Top50SelfAverage  = $top50SelfAverage
+        Top50Duration     = [Profiler.LineProfile[]] $top50Duration
+        Top50Average      = [Profiler.LineProfile[]] $top50Average
+        Top50HitCount     = [Profiler.LineProfile[]] $top50HitCount
+        Top50SelfDuration = [Profiler.LineProfile[]] $top50SelfDuration
+        Top50SelfAverage  = [Profiler.LineProfile[]] $top50SelfAverage
         TotalDuration     = $total
         StopwatchDuration = $out.Stopwatch
-        AllLines          = $all
-        Events            = $trace
+        AllLines          = [Profiler.LineProfile[]] $all
+        Events            = [System.Collections.Generic.List[Profiler.ProfileEventRecord]] $trace
         # Files             = foreach ($pair in $fileMap.GetEnumerator()) {
         #     [PSCustomObject]@{
         #         Path = $pair.Key

--- a/Profiler/Trace-Script.ps1
+++ b/Profiler/Trace-Script.ps1
@@ -254,14 +254,7 @@ function Trace-Script {
             $commandHit.HitCount++
         }
         else { 
-            $commandHit = [Profiler.CommandHit] @{
-                Line         = $hit.Line # start from 1 as in file
-                Column       = $hit.Column
-                SelfDuration = $hit.SelfDuration
-                # Duration     = 0 # Not available in class
-                # HitCount     = 1
-                Text         = $hit.Text
-            }
+            $commandHit = [Profiler.CommandHit]::new($hit)
             $lineProfile.CommandHits.Add($hit.Column, $commandHit)
         }
     }

--- a/Profiler/Trace-Script.ps1
+++ b/Profiler/Trace-Script.ps1
@@ -344,16 +344,17 @@ function Trace-Script {
     Sort-Object -Property HitCount -Descending | 
     Select-Object -First 50
 
-    $script:processedTrace = [PSCustomObject] @{ 
-        Top50Duration     = [Profiler.LineProfile[]] $top50Duration
-        Top50Average      = [Profiler.LineProfile[]] $top50Average
-        Top50HitCount     = [Profiler.LineProfile[]] $top50HitCount
-        Top50SelfDuration = [Profiler.LineProfile[]] $top50SelfDuration
-        Top50SelfAverage  = [Profiler.LineProfile[]] $top50SelfAverage
+
+    $script:processedTrace = [Profiler.Trace] @{ 
+        Top50Duration     = $top50Duration
+        Top50Average      = $top50Average
+        Top50HitCount     = $top50HitCount
+        Top50SelfDuration = $top50SelfDuration
+        Top50SelfAverage  = $top50SelfAverage
         TotalDuration     = $total
         StopwatchDuration = $out.Stopwatch
-        AllLines          = [Profiler.LineProfile[]] $all
-        Events            = [System.Collections.Generic.List[Profiler.ProfileEventRecord]] $trace
+        AllLines          = $all
+        Events            = $trace
         # Files             = foreach ($pair in $fileMap.GetEnumerator()) {
         #     [PSCustomObject]@{
         #         Path = $pair.Key

--- a/Profiler/Trace-Script.ps1
+++ b/Profiler/Trace-Script.ps1
@@ -211,20 +211,10 @@ function Trace-Script {
         $lineNumber = $hit.Line
         if (-not $file.Lines.ContainsKey($lineNumber)) {
             $lineProfile = [Profiler.LineProfile] @{
-                # Percent      = 0
-                # HitCount     = 0 
-                # Duration     = [TimeSpan]::Zero
-                # Average      = [TimeSpan]::Zero
-                # SelfDuration = [TimeSpan]::Zero
-                # SelfAverage  = [TimeSpan]::Zero
-    
                 Name         = $file.Name
                 Line         = $lineNumber
                 Text         = $hit.Text
                 Path         = $key
-                # IsInFile     = $false # Not available in class
-                # Hits         = [System.Collections.Generic.List[Profiler.ProfileEventRecord]]::new()
-                # CommandHits  = New-Object 'System.Collections.Generic.Dictionary[Uint,Profiler.CommandHit]'
             }
             $file.Lines.Add($lineNumber, $lineProfile)
         }
@@ -348,13 +338,6 @@ function Trace-Script {
         StopwatchDuration = $out.Stopwatch
         AllLines          = $all
         Events            = $trace
-        # Files             = foreach ($pair in $fileMap.GetEnumerator()) {
-        #     [PSCustomObject]@{
-        #         Path = $pair.Key
-        #         Name = $pair.Value.Name
-        #         Lines = $pair.Value.Lines | Sort-Object -Property Name
-        #     }
-        # }
     }
 
     $script:processedTrace

--- a/Profiler/Trace-ScriptInternal.ps1
+++ b/Profiler/Trace-ScriptInternal.ps1
@@ -69,7 +69,7 @@ function Trace-ScriptInternal {
         Write-Host -Foreground Magenta  "Run$(if (1 -lt $sides.Count) { " - $side" }) finished after $($result.Stopwatch)"
     }
     else {
-        Write-Host -ForegroundColor Red "Run$(if (1 -lt $sides.Count) { " - $side" }) failed after $($result.Stopwatch) with $($result.Error)."
+        Write-Host -ForegroundColor Red "Run$(if (1 -lt $sides.Count) { " - $side" }) failed after $($result.Stopwatch) with the following error:`n$($result.Error)."
     }
 
     $out.Stopwatch = $result.Stopwatch

--- a/csharp/Profiler/CommandHit.cs
+++ b/csharp/Profiler/CommandHit.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 namespace Profiler
 {

--- a/csharp/Profiler/CommandHit.cs
+++ b/csharp/Profiler/CommandHit.cs
@@ -31,5 +31,13 @@ namespace Profiler
         /// Command text.
         /// </summary>
         public string Text { get; set; }
+
+        public CommandHit(ProfileEventRecord hit)
+        {
+            Line         = (uint)hit.Line;
+            Column       = (uint)hit.Column;
+            SelfDuration = hit.SelfDuration;
+            Text         = hit.Text;
+        }
     }
 }

--- a/csharp/Profiler/CommandHit.cs
+++ b/csharp/Profiler/CommandHit.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+
+namespace Profiler
+{
+    /// <summary>
+    /// Represents a command hit on a line
+    /// </summary>
+    public class CommandHit
+    {
+        /// <summary>
+        /// Line number of the command in the file or scriptblock.
+        /// </summary>
+        public uint Line { get; set; }
+
+        /// <summary>
+        /// Column of the command in the file or scriptblock.
+        /// </summary>
+        public uint Column { get; set; }
+
+        /// <summary>
+        /// Number of hits on command.
+        /// </summary>
+        public uint HitCount { get; set; } = 1;
+
+        /// <summary>
+        /// Time used exclusively by this command
+        /// </summary>
+        public TimeSpan SelfDuration { get; set; }
+
+        /// <summary>
+        /// Command text.
+        /// </summary>
+        public string Text { get; set; }
+    }
+}

--- a/csharp/Profiler/LineProfile.cs
+++ b/csharp/Profiler/LineProfile.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+
+namespace Profiler
+{
+    /// <summary>
+    /// Represents a profiled line.
+    /// </summary>
+    public class LineProfile
+    {
+        /// <summary>
+        /// Percent of total duration used by line.
+        /// </summary>
+        public double Percent { get; set; } = 0.00;
+
+        /// <summary>
+        /// Number of hits on line.
+        /// </summary>
+        public uint HitCount { get; set; } = 0;
+
+        /// <summary>
+        /// Time used by line including subcalls.
+        /// </summary>
+        public TimeSpan Duration { get; set; } = TimeSpan.Zero;
+
+        /// <summary>
+        /// Average of duration for all hits.
+        /// </summary>
+        public TimeSpan Average { get; set; } = TimeSpan.Zero;
+
+        /// <summary>
+        /// Time used exclusively by this line.
+        /// </summary>
+        public TimeSpan SelfDuration { get; set; } = TimeSpan.Zero;
+
+        /// <summary>
+        /// Average of SelfDuration for all hits.
+        /// </summary>
+        public TimeSpan SelfAverage { get; set; } = TimeSpan.Zero;
+
+        /// <summary>
+        /// Name of file or id of scriptblock the line belongs to.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Line number in the file or scriptblock.
+        /// </summary>
+        public uint Line { get; set; }
+
+        /// <summary>
+        /// Text of line.
+        /// </summary>
+        public string Text { get; set; }
+
+        /// <summary>
+        /// Absolute path of file or id of scriptblock the line belongs to.
+        /// </summary>
+        public string Path { get; set; }
+
+        /// <summary>
+        /// Event records for all hits to the line.
+        /// </summary>
+        public ICollection<ProfileEventRecord> Hits { get; set; } = new List<ProfileEventRecord>();
+
+        /// <summary>
+        /// All command hits in this line using column as key.
+        /// </summary>
+        public IDictionary<uint, CommandHit> CommandHits { get; set; } = new Dictionary<uint, CommandHit>();
+    }
+}

--- a/csharp/Profiler/Trace.cs
+++ b/csharp/Profiler/Trace.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace Profiler
+{
+    /// <summary>
+    /// Trace-Script output type.
+    /// </summary>
+    public class Trace
+    {
+        public Profiler.LineProfile[] Top50Duration { get; set; }
+        public Profiler.LineProfile[] Top50Average { get; set; }
+        public Profiler.LineProfile[] Top50HitCount { get; set; }
+        public Profiler.LineProfile[] Top50SelfDuration { get; set; }
+        public Profiler.LineProfile[] Top50SelfAverage { get; set; }
+        public TimeSpan TotalDuration { get; set; }
+        public TimeSpan StopwatchDuration { get; set; }
+        public Profiler.LineProfile[] AllLines { get; set; }
+        public List<ProfileEventRecord> Events { get; set; }
+    }
+}


### PR DESCRIPTION
Initial version of C# classes for output types as mentioned in this [issue comment](https://github.com/nohwnd/Profiler/issues/9#issuecomment-830828861)
Will make it easier to add formatting on and be faster.

- [x] Add classes
- [x] Update Trace-Script
- [ ] Cleanup commented property assignments in Trace-Script (waiting for review first)

PR also slightly updates error message to better separate Profiler-string from actual error message. 

Before: 
![image](https://user-images.githubusercontent.com/3436158/116944669-375ea500-ac76-11eb-9c32-97c00db29543.png)

After:
![image](https://user-images.githubusercontent.com/3436158/116944683-40e80d00-ac76-11eb-8ad7-e0f8411ef4d5.png)
