### PR TITLE
MyScript.ps1 "before" code should build an array

### DIFF
--- a/demo-scripts/MyScript.ps1
+++ b/demo-scripts/MyScript.ps1
@@ -14,6 +14,7 @@ if ($_profiler) {
 else {
     # before changes
     Write-Host "before"
+    $newValues = @()
     $Values | foreach {
         $newValues += $_ + 10
     }

--- a/demo3.ps1
+++ b/demo3.ps1
@@ -1,24 +1,24 @@
 ### SleepyScript.ps1
-function a () { 
+function a () {
     Start-Sleep -Milliseconds 100
  }
- 
- function b () { 
+
+ function b () {
      a
  }
- 
+
  function c () {
      a
      b
  }
- 
+
 c
 
 ## Duration per-line and per itself, and finding what was slow
 Import-Module $PSScriptRoot/Profiler/Profiler.psm1 -Force
 
 # Runs the script
-$trace = Trace-Script { & "demo-scripts/SleepyScript.ps1" }
+$trace = Trace-Script { & "$PSScriptRoot/demo-scripts/SleepyScript.ps1" }
 
 $trace.Top50Duration | Format-Table
 
@@ -26,13 +26,13 @@ $trace.Top50Duration | Format-Table
 $slowLine = $trace.Top50Duration | Where-Object text -eq 'c'
 $slowLine | Format-Table
 
-# it was called just once (hit), and by itself (SelfDuration) takes < 1ms, but the code it calls 
+# it was called just once (hit), and by itself (SelfDuration) takes < 1ms, but the code it calls
 # takes over 200 ms (Duration), let's see what happens in the meantime
 $hit = $slowLine.Hits[0]
 $trace.Events[$hit.Index..$hit.ReturnIndex] | Format-Table
 
 # and if that is too many calls, let's see the top 50 from that that themselves take the most
-$trace.Events[$hit.Index..$hit.ReturnIndex] | 
-    Sort-Object -Descending SelfDuration | 
-    Select-Object -First 50 | 
+$trace.Events[$hit.Index..$hit.ReturnIndex] |
+    Sort-Object -Descending SelfDuration |
+    Select-Object -First 50 |
     Format-Table

--- a/demo3.ps1
+++ b/demo3.ps1
@@ -1,24 +1,24 @@
 ### SleepyScript.ps1
-function a () {
+function a () { 
     Start-Sleep -Milliseconds 100
  }
-
- function b () {
+ 
+ function b () { 
      a
  }
-
+ 
  function c () {
      a
      b
  }
-
+ 
 c
 
 ## Duration per-line and per itself, and finding what was slow
 Import-Module $PSScriptRoot/Profiler/Profiler.psm1 -Force
 
 # Runs the script
-$trace = Trace-Script { & "$PSScriptRoot/demo-scripts/SleepyScript.ps1" }
+$trace = Trace-Script { & "demo-scripts/SleepyScript.ps1" }
 
 $trace.Top50Duration | Format-Table
 
@@ -26,13 +26,13 @@ $trace.Top50Duration | Format-Table
 $slowLine = $trace.Top50Duration | Where-Object text -eq 'c'
 $slowLine | Format-Table
 
-# it was called just once (hit), and by itself (SelfDuration) takes < 1ms, but the code it calls
+# it was called just once (hit), and by itself (SelfDuration) takes < 1ms, but the code it calls 
 # takes over 200 ms (Duration), let's see what happens in the meantime
 $hit = $slowLine.Hits[0]
 $trace.Events[$hit.Index..$hit.ReturnIndex] | Format-Table
 
 # and if that is too many calls, let's see the top 50 from that that themselves take the most
-$trace.Events[$hit.Index..$hit.ReturnIndex] |
-    Sort-Object -Descending SelfDuration |
-    Select-Object -First 50 |
+$trace.Events[$hit.Index..$hit.ReturnIndex] | 
+    Sort-Object -Descending SelfDuration | 
+    Select-Object -First 50 | 
     Format-Table

--- a/demo3.ps1
+++ b/demo3.ps1
@@ -18,7 +18,7 @@ c
 Import-Module $PSScriptRoot/Profiler/Profiler.psm1 -Force
 
 # Runs the script
-$trace = Trace-Script { & "demo-scripts/SleepyScript.ps1" }
+$trace = Trace-Script { & "$PSScriptRoot/demo-scripts/SleepyScript.ps1" }
 
 $trace.Top50Duration | Format-Table
 


### PR DESCRIPTION
To compare apples to apples in this demo script, the "before" code should build an array (not an integer).