### PR TITLE
Fix code and lines

### DIFF
--- a/Profiler/Profiler.psd1
+++ b/Profiler/Profiler.psd1
@@ -8,7 +8,7 @@
 RootModule = 'Profiler.psm1'
 
 # Version number of this module.
-ModuleVersion = '3.1.0'
+ModuleVersion = '3.1.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/csharp/Profiler/Profiler.cs
+++ b/csharp/Profiler/Profiler.cs
@@ -94,6 +94,7 @@ namespace Profiler
             var contentMap = new Dictionary<Guid, string[]>();
             var returnIndexPerLineMap = new Dictionary<Guid, Dictionary<int, int>>();
             var traceCount = trace.Count;
+            var newLineArray = new string[] { Environment.NewLine };
 
             ScriptBlock lastScriptBlock = null;
             // excluding start and stop internal events
@@ -106,7 +107,7 @@ namespace Profiler
                 {
                     lastScriptBlock = scriptBlocks[key];
                     // there is an edge case when using classes that will fail to convert to string
-                    try { lines = lastScriptBlock?.ToString().Split('\n'); } catch { lines = null; }
+                    try { lines = lastScriptBlock?.Ast.ToString().Split(newLineArray, StringSplitOptions.None); } catch { lines = null; }
                     contentMap.Add(key, lines);
                 }
 


### PR DESCRIPTION
Scriptblock.ToString() and ScriptBlock.Ast.ToString() are each different. The Ast one is what we need to have the lines in code and on the scriptblock agree. Otherwise they are offset depending on whether or not param is used.