### PR TITLE
Fix function summary

### DIFF
--- a/csharp/Profiler/Profiler.cs
+++ b/csharp/Profiler/Profiler.cs
@@ -204,15 +204,15 @@ namespace Profiler
             {
                 var hit = trace[i];
 
-                var key = hit.Module + "|" + hit.Function;
+                var key = hit.Module + "|" + hit.Function + "|" + (hit.IsInFile ? hit.Path : hit.ScriptBlockId);
 
                 if (!functionMap.TryGetValue(key, out var lineProfile))
                 {
                     lineProfile = new LineProfile
                     {
                         File = hit.Path,
-                        Text = hit.Function,
-                        Function = hit.Function,
+                        Text = hit.Function ?? "<body>",
+                        Function = hit.Function ?? "<body>",
                         Module = hit.Module,
                         Path = hit.Path,
                     };

--- a/demo.ps1
+++ b/demo.ps1
@@ -2,9 +2,7 @@
 
 Import-Module $PSScriptRoot/Profiler/Profiler.psd1 -Force
 
-$trace =  Trace-Script -ScriptBlock { 
-    
-    start-sleep -Seconds 4
+$trace =  Trace-Script -ScriptBlock {
     & "$PSScriptRoot/demo-scripts/Get-Icons.ps1" } -ExportPath emojis.speedscope.json
 
 # Shows the top 50 lines that take the most percent of the run by themselves

--- a/demo.ps1
+++ b/demo.ps1
@@ -2,7 +2,10 @@
 
 Import-Module $PSScriptRoot/Profiler/Profiler.psd1 -Force
 
-$trace =  Trace-Script -ScriptBlock { & "$PSScriptRoot/demo-scripts/Get-Icons.ps1" } -ExportPath emojis.speedscope.json
+$trace =  Trace-Script -ScriptBlock { 
+    
+    start-sleep -Seconds 4
+    & "$PSScriptRoot/demo-scripts/Get-Icons.ps1" } -ExportPath emojis.speedscope.json
 
 # Shows the top 50 lines that take the most percent of the run by themselves
 $trace.Top50SelfDuration | Format-Table


### PR DESCRIPTION
Function summary shows `<body>` in the function name, for code that is not in any function. And splits it by file / scriptblock, so every code that is not in a function is not mushed up into single big blob that takes most of the time.

Fix #55